### PR TITLE
Don't use git to build spec file list

### DIFF
--- a/metanorma-cli.gemspec
+++ b/metanorma-cli.gemspec
@@ -14,9 +14,8 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/riboseinc/metanorma"
   spec.license       = "BSD-2-Clause"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
-  end
+  spec.files         = Dir['**/*'].reject { |f| f.match(%r{^(test|spec|features|.git)/}) }
+
   spec.extra_rdoc_files = %w[README.adoc LICENSE]
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
According to best practices better to not use git to build `spec.files`, https://stackoverflow.com/questions/16203163/what-are-the-best-practices-for-updating-a-gemspecs-file-list

This will fix CI error in https://travis-ci.org/riboseinc/homebrew-metanorma (after release of course)